### PR TITLE
FIX: Correct in place modification loop that was removing wrong warnings

### DIFF
--- a/operations/reprioritise.py
+++ b/operations/reprioritise.py
@@ -23,13 +23,13 @@ class Reprioritise:
             found_positions = set()
 
             # Print the type of json_array variable
-            print("Type:", type(json_array))
+            # print("Type:", type(json_array))
             for position, obj in enumerate(json_array):
                 if obj["symbol"] in low_priority_symbols_list:
                     found_positions.add(position)
 
-            print("found_positions", found_positions)
-            print("Original length:", len(json_array))
+            print("Position of recommendations found that are to be filtered:", found_positions)
+            print("Original number of pylint recommendations:", len(json_array))
 
             for position in found_positions:
                 json_array.append(json_array[position])
@@ -37,7 +37,7 @@ class Reprioritise:
 
             json_array = [element for i, element in enumerate(json_array)
                           if not i in found_positions]
-            print("After filter operations length:", len(json_array))
+            print("After filter operations length (expected to be the same as original number of pylint recommendations):", len(json_array))
 
         with open(input_location, 'w') as outfile:
             json.dump(json_array, outfile, indent=4)

--- a/operations/reprioritise.py
+++ b/operations/reprioritise.py
@@ -20,13 +20,13 @@ class Reprioritise:
         with open(input_location) as json_file:
             json_array = json.load(json_file)
 
-            found_positions = []
+            found_positions = set()
 
             # Print the type of json_array variable
             print("Type:", type(json_array))
             for position, obj in enumerate(json_array):
                 if obj["symbol"] in low_priority_symbols_list:
-                    found_positions.append(position)
+                    found_positions.add(position)
 
             print("found_positions", found_positions)
             print("Original length:", len(json_array))
@@ -35,9 +35,9 @@ class Reprioritise:
                 json_array.append(json_array[position])
             print("After append operations length:", len(json_array))
 
-            for i, position in enumerate(found_positions):
-                json_array.pop(position - i) # compensate for number of removed warnings
-            print("After pop operations length:", len(json_array))
+            json_array = [element for i, element in enumerate(json_array)
+                          if not i in found_positions]
+            print("After filter operations length:", len(json_array))
 
         with open(input_location, 'w') as outfile:
             json.dump(json_array, outfile, indent=4)

--- a/operations/reprioritise.py
+++ b/operations/reprioritise.py
@@ -35,8 +35,8 @@ class Reprioritise:
                 json_array.append(json_array[position])
             print("After append operations length:", len(json_array))
 
-            for position in found_positions:
-                json_array.pop(position)
+            for i, position in enumerate(found_positions):
+                json_array.pop(position - i) # compensate for number of removed warnings
             print("After pop operations length:", len(json_array))
 
         with open(input_location, 'w') as outfile:


### PR DESCRIPTION
Before Fix (note that some trailing-whitespace warnings are still present at top of context-aware output):
![mlhound-diff-crop](https://user-images.githubusercontent.com/789037/137852642-2bd85dc3-2f2e-4ccf-a777-b78381b81414.png)

After Fix:
![mlhound-diff-fixed](https://user-images.githubusercontent.com/789037/137853986-264d1d09-b16e-4dc6-979b-587039c684d2.png)

